### PR TITLE
Fixes module name conflict in Debian build process.

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-ansible (0.8) unstable; urgency=low
+ansible-provisioning (0.8) unstable; urgency=low
   
   * 0.8 release pending
  


### PR DESCRIPTION
The Debian package build was failing with the error:

```
dpkg-gencontrol: error: source package has two conflicting values - ansible-provisioning and ansible
```

Updated with ansible-provisioning in place of ansible resolve.
