### PR TITLE
Add health & RAM reporting

### DIFF
--- a/library/hpilo_facts
+++ b/library/hpilo_facts
@@ -79,6 +79,7 @@ notes:
 '''
 
 import sys
+import re
 import warnings
 try:
     import hpilo
@@ -165,6 +166,25 @@ def main():
         elif entry['type'] == 233:  # Embedded NIC MAC Assignment (Alternate data format)
             (factname, entry_facts) = parse_flat_interface(entry, 'hw_eth_ilo')
             facts[factname] = entry_facts
+
+    # collect health (RAM/CPU data)
+    health = ilo.get_embedded_health()
+    facts['hw_health'] = health
+    memory_details_summary = health.get('memory', {}).get('memory_details_summary')
+    # RAM as reported by iLO 2.10 on ProLiant BL460c Gen8
+    if memory_details_summary:
+        facts['hw_memory_details_summary'] = memory_details_summary
+        facts['hw_memory_total'] = 0
+        for cpu, details in memory_details_summary.iteritems():
+            cpu_total_memory_size = details.get('total_memory_size')
+            if cpu_total_memory_size:
+                ram = re.search('(\d+)\s+(\w+)', cpu_total_memory_size)
+                if ram:
+                    if ram.group(2) == 'GB':
+                        facts['hw_memory_total'] = facts['hw_memory_total'] + int(ram.group(1))
+
+        # reformat into a text friendly format
+        facts['hw_memory_total'] = "{0} GB".format(facts['hw_memory_total'])
 
     module.exit_json(ansible_facts=facts)
 


### PR DESCRIPTION
* export the ilo.get_embedded_health() results via hw_health fact
* parse the results of  ilo.get_embedded_health() on ProLiant BL460c Gen8 to report via hw_memory_total