### PR TITLE
Allow configuration of manual mac address.

### DIFF
--- a/library/vsphere_guest
+++ b/library/vsphere_guest
@@ -248,7 +248,7 @@ def add_cdrom(module, s, config_target, config, devices, default_devs, type="cli
         devices.append(cd_spec)
 
 
-def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard"):
+def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name="VM Network", network_type="standard", mac_address=None):
     ### add a NIC 
     # Different network card types are: "VirtualE1000", "VirtualE1000e","VirtualPCNet32", "VirtualVmxnet", "VirtualNmxnet2", "VirtualVmxnet3"
     nic_spec = config.new_deviceChange()
@@ -289,8 +289,11 @@ def add_nic(module, s, nfmor, config, devices, nic_type="vmxnet3", network_name=
         s.disconnect()
         module.fail_json(msg="Error adding nic backing to vm spec. No network type of: %s" % (network_type))
 
-        
-    nic_ctlr.set_element_addressType("generated")
+    if mac_address:
+        nic_ctlr.set_element_addressType('manual')
+        nic_ctlr.set_element_macAddress(mac_address)
+    else:
+        nic_ctlr.set_element_addressType("generated")
     nic_ctlr.set_element_backing(nic_backing)
     nic_ctlr.set_element_key(4)
     nic_spec.set_element_device(nic_ctlr)
@@ -616,9 +619,10 @@ def main():
                 network_type = vm_nic[nic]['network_type']
             except KeyError:
                 s.disconnect()
-                module.fail_json(msg="Error on %s definition. network_type needs to be specified." % nic) 
+                module.fail_json(msg="Error on %s definition. network_type needs to be specified." % nic)
+            mac_address = vm_nic[nic]['mac_address'] if 'mac_address' in vm_nic[nic] else None
             # Add the nic to the VM spec.
-            add_nic(module, s, nfmor, config, devices, nictype, network, network_type)
+            add_nic(module, s, nfmor, config, devices, nictype, network, network_type, mac_address)
     
     
     config.set_element_deviceChange(devices)
@@ -641,9 +645,9 @@ def main():
         s.disconnect()
         module.fail_json(msg="Error creating vm: %s" % task.get_error_message())
     else:
-	vm = None
-	if vm_extra_config or power_on:
-        	vm = s.get_vm_by_name(vm_name)    
+        vm = None
+        if vm_extra_config or power_on:
+            vm = s.get_vm_by_name(vm_name)
 
         # VM was created. If there is any extra config options specified, set them here , disconnect from vcenter, then exit.
         if vm_extra_config:


### PR DESCRIPTION
Add a new `mac_address` option to the network interface configuration. If specified, it is used instead of generated mac address.
