### PR TITLE
Enable setting firmware type (bios or efi).

### DIFF
--- a/library/vsphere_guest
+++ b/library/vsphere_guest
@@ -392,6 +392,7 @@ def main():
             datastore            = dict(required=True, type='str'),
             esxi_hostname        = dict(required=True, type='str'),
             power_on             = dict(required=False, default='no', type='bool'),
+            firmware             = dict(required=False, default="bios", choices=['bios', 'efi']),
             vm_name              = dict(required=True, type='str'),
             vm_memory_mb         = dict(required=False, default=1024),
             vm_num_cpus          = dict(required=False, default=1),
@@ -428,6 +429,7 @@ def main():
     vm_notes = module.params['vm_notes']
     vm_cdrom = module.params['vm_cdrom']
     vm_extra_config = module.params['vm_extra_config']
+    firmware = module.params['firmware']
     guestosid = module.params['guestosid']
 
 
@@ -553,6 +555,7 @@ def main():
     config.set_element_memoryMB(vm_memory_mb)
     config.set_element_numCPUs(vm_num_cpus)
     config.set_element_guestId(guestosid)
+    config.set_element_firmware(firmware)
     devices = []
     
     # Attach all the hardware we want to the VM spec.


### PR DESCRIPTION
Add a new action parameter to select the firmware to use for booting the VM. It defaults to BIOS for compatibility with existing playbooks.
